### PR TITLE
Deployment on kind

### DIFF
--- a/kind/core.yml
+++ b/kind/core.yml
@@ -28,8 +28,7 @@ spec:
                 - "core"
       containers:
       - name: core
-        # image: "ghcr.io/funlessdev/fl-core:latest"
-        image: "fl-core-local:latest"
+        image: "ghcr.io/funlessdev/fl-core:latest"
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 4000

--- a/kind/core.yml
+++ b/kind/core.yml
@@ -33,7 +33,6 @@ spec:
         ports:
         - containerPort: 4000
         - containerPort: 4369
-        - containerPort: 45892
         env:
         - name: SECRET_KEY_BASE
           value: "core_secret_key"

--- a/kind/core.yml
+++ b/kind/core.yml
@@ -1,0 +1,66 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fl-core
+  namespace: fl
+  labels:
+    app: fl-core
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: fl-core
+  template:
+    metadata:
+      labels:
+        app: fl-core
+    spec:
+      serviceAccountName: fl-svc-account
+      restartPolicy: "Always"
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: fl
+                operator: In
+                values:
+                - "core"
+      containers:
+      - name: core
+        # image: "ghcr.io/funlessdev/fl-core:latest"
+        image: "fl-core-local:latest"
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 4000
+        - containerPort: 4369
+        - containerPort: 45892
+        env:
+        - name: SECRET_KEY_BASE
+          value: "core_secret_key"
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: DEPLOY_ENV
+          value: "kubernetes"
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: fl-core-service
+  namespace: fl
+  labels:
+    app: fl-core
+spec:
+  type: NodePort
+  selector:
+    app: fl-core
+  ports:
+    - name: http
+      port: 4000
+      targetPort: 4000
+      nodePort: 30210
+      protocol: TCP

--- a/kind/kind-cluster.yml
+++ b/kind/kind-cluster.yml
@@ -4,7 +4,11 @@ name: funless-cluster
 nodes:
   - role: control-plane
   - role: worker
+    labels:
+      fl: core
     extraPortMappings:
-      - hostPort: 4000
-        containerPort: 4000
+    - hostPort: 4000
+      containerPort: 30210
   - role: worker
+    labels:
+      fl: worker

--- a/kind/namespace.yml
+++ b/kind/namespace.yml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: fl

--- a/kind/prometheus.yml
+++ b/kind/prometheus.yml
@@ -27,7 +27,7 @@ spec:
                 values:
                 - "core"
       containers:
-      - name: core
+      - name: prometheus
         image: "giusdp/fl-prometheus:latest"
         imagePullPolicy: IfNotPresent
         ports:

--- a/kind/prometheus.yml
+++ b/kind/prometheus.yml
@@ -15,6 +15,7 @@ spec:
       labels:
         app: fl-prometheus
     spec:
+      serviceAccountName: fl-svc-account
       restartPolicy: "Always"
       affinity:
         nodeAffinity:

--- a/kind/prometheus.yml
+++ b/kind/prometheus.yml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fl-prometheus
+  namespace: fl
+  labels:
+    app: fl-prometheus
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: fl-prometheus
+  template:
+    metadata:
+      labels:
+        app: fl-prometheus
+    spec:
+      restartPolicy: "Always"
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: fl
+                operator: In
+                values:
+                - "core"
+      containers:
+      - name: core
+        image: "giusdp/fl-prometheus:latest"
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 9090
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus
+  namespace: fl
+  labels:
+    app: fl-prometheus
+spec:
+  type: ClusterIP
+  selector:
+    app: fl-prometheus
+  ports:
+    - name: http
+      port: 9090
+      targetPort: 9090
+      protocol: TCP

--- a/kind/prometheus/Dockerfile
+++ b/kind/prometheus/Dockerfile
@@ -1,0 +1,15 @@
+FROM prom/prometheus:v2.39.1
+
+# Add the configuration file
+ADD ./config.yml /etc/prometheus/prometheus.yml
+
+# Start the Prometheus server
+
+USER       nobody
+EXPOSE     9090
+VOLUME     [ "/prometheus" ]
+ENTRYPOINT [ "/bin/prometheus" ]
+CMD        [ "--config.file=/etc/prometheus/prometheus.yml", \
+    "--storage.tsdb.path=/prometheus", \
+    "--web.console.libraries=/usr/share/prometheus/console_libraries", \
+    "--web.console.templates=/usr/share/prometheus/consoles" ]

--- a/kind/prometheus/config.yml
+++ b/kind/prometheus/config.yml
@@ -1,0 +1,21 @@
+# Global Configurations
+global:
+  scrape_interval: 5s
+  evaluation_interval: 5s
+
+  external_labels:
+    monitor: "funless"
+
+# Targets to scrape
+scrape_configs:
+  - job_name: "prometheus"
+    static_configs:
+      - targets: ["localhost:9090"]
+
+  - job_name: "funless"
+    kubernetes_sd_configs:
+      - role: "pod"
+        namespaces:
+          own_namespace: true
+
+

--- a/kind/start_kind.sh
+++ b/kind/start_kind.sh
@@ -11,3 +11,8 @@ kind create cluster --config "$SCRIPTDIR/kind-cluster.yml" --image kindest/node:
 
 echo "Kubernetes cluster is deployed and reachable"
 kubectl cluster-info --context kind-funless-cluster
+kubectl apply -f namespace.yml
+kubectl apply -f svc-account.yml
+kubectl apply -f prometheus.yml
+kubectl apply -f core.yml
+kubectl apply -f worker.yml

--- a/kind/svc-account.yml
+++ b/kind/svc-account.yml
@@ -19,6 +19,7 @@ rules:
     verbs:
       - list
       - get
+      - watch
 
 ---
 

--- a/kind/svc-account.yml
+++ b/kind/svc-account.yml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: fl-svc-account
+  namespace: fl
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: fl-role
+  namespace: fl
+rules:
+  - apiGroups:
+    - ""
+    resources:
+      - pods
+    verbs:
+      - list
+      - get
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: fl-rolebinding
+  namespace: fl
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: fl-role
+subjects:
+  - kind: ServiceAccount
+    name: fl-svc-account

--- a/kind/worker.yml
+++ b/kind/worker.yml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: fl-worker
+  namespace: fl
+  labels:
+    app: fl-worker
+spec:
+  selector:
+    matchLabels:
+      app: fl-worker
+  template:
+    metadata:
+      labels:
+        app: fl-worker
+    spec:
+      serviceAccountName: fl-svc-account
+      restartPolicy: "Always"
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: fl
+                operator: In
+                values:
+                - "worker"
+      containers:
+      - name: worker
+        # image: "ghcr.io/funlessdev/fl-worker:latest"
+        image: "fl-worker-local:latest"
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 4369
+        - containerPort: 45892
+        env:
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: DEPLOY_ENV
+          value: "kubernetes"

--- a/kind/worker.yml
+++ b/kind/worker.yml
@@ -27,8 +27,7 @@ spec:
                 - "worker"
       containers:
       - name: worker
-        # image: "ghcr.io/funlessdev/fl-worker:latest"
-        image: "fl-worker-local:latest"
+        image: "ghcr.io/funlessdev/fl-worker:latest"
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 4369

--- a/kind/worker.yml
+++ b/kind/worker.yml
@@ -30,8 +30,8 @@ spec:
         image: "ghcr.io/funlessdev/fl-worker:latest"
         imagePullPolicy: IfNotPresent
         ports:
+        - containerPort: 4021
         - containerPort: 4369
-        - containerPort: 45892
         env:
         - name: NODE_IP
           valueFrom:


### PR DESCRIPTION
This PR adds the necessary manifest and configuration files for the deployment of the plaform on kind.

Specifically it adds:
- manifest files for worker, core, prometheus
- dockerfile and config file for the necessary version of prometheus
- dedicated kubernetes service account and namespace for the platform

This closes #1.