### PR TITLE
Use ConfigMag to Configure Prometheus

### DIFF
--- a/kind/prometheus-cm.yml
+++ b/kind/prometheus-cm.yml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fl-prometheus-configmap
+  namespace: fl
+  labels:
+    name: fl-prometheus-configmap
+data:
+  prometheus.yml: |-
+    # Global Configurations
+    global:
+      scrape_interval: 5s
+      evaluation_interval: 5s
+
+      external_labels:
+        monitor: "funless"
+
+    # Targets to scrape
+    scrape_configs:
+      - job_name: "prometheus"
+        static_configs:
+          - targets: ["localhost:9090"]
+
+      - job_name: "funless"
+        kubernetes_sd_configs:
+          - role: "pod"
+            namespaces:
+              own_namespace: true

--- a/kind/prometheus.yml
+++ b/kind/prometheus.yml
@@ -26,12 +26,19 @@ spec:
                 operator: In
                 values:
                 - "core"
+      volumes:
+        - name: fl-prometheus-config-volume
+          configMap:
+            name: fl-prometheus-configmap
       containers:
       - name: prometheus
-        image: "giusdp/fl-prometheus:latest"
+        image: "prom/prometheus:latest"
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9090
+        volumeMounts:
+        - name: fl-prometheus-config-volume
+          mountPath: /etc/prometheus/
 
 ---
 

--- a/kind/start_kind.sh
+++ b/kind/start_kind.sh
@@ -13,6 +13,7 @@ echo "Kubernetes cluster is deployed and reachable"
 kubectl cluster-info --context kind-funless-cluster
 kubectl apply -f namespace.yml
 kubectl apply -f svc-account.yml
+kubectl apply -f prometheus-cm.yml
 kubectl apply -f prometheus.yml
 kubectl apply -f core.yml
 kubectl apply -f worker.yml


### PR DESCRIPTION
This PR reverts the Prometheus pod in the kind/k8s deployment to the default Prometheus image.
The configuration is now passed as a ConfigMap.

This closes #6, as the docker-compose deployment already passes the configuration as a bind mount.