### PR TITLE
Add postgres in kind/k8s deployment

### DIFF
--- a/kind/postgres.yml
+++ b/kind/postgres.yml
@@ -1,0 +1,101 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fl-postgres
+  namespace: fl
+  labels:
+    app: fl-postgres
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: fl-postgres
+  template:
+    metadata:
+      labels:
+        app: fl-postgres
+    spec:
+      serviceAccountName: fl-svc-account
+      restartPolicy: "Always"
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: fl
+                operator: In
+                values:
+                - "core"
+      containers:
+      - name: postgres
+        image: "postgres:latest"
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 5432
+        env:
+        - name: POSTGRES_PASSWORD
+          value: postgres
+        - name: POSTGRES_USER
+          value: postgres
+        - name: POSTGRES_HOST_AUTH_METHOD
+          value: trust
+
+---
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: fl-init-postgres
+  namespace: fl
+  labels:
+    app: fl-init-postgres
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      name: fl-init-postgres
+      labels:
+        app: fl-init-postgres
+    spec:
+      serviceAccountName: fl-svc-account
+      restartPolicy: "Never"
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: fl
+                operator: In
+                values:
+                - "core"
+      containers:
+      - name: init-postgres
+        image: "postgres:latest"
+        imagePullPolicy: IfNotPresent
+        command:  ["/bin/bash", "-c", "while ! pg_isready -h postgres -U postgres; do sleep 1; done; psql -h postgres -U postgres -c 'CREATE DATABASE funless;'"]
+        env:
+        - name: POSTGRES_PASSWORD
+          value: postgres
+        - name: POSTGRES_USER
+          value: postgres
+        - name: POSTGRES_HOST_AUTH_METHOD
+          value: trust
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  namespace: fl
+  labels:
+    app: fl-postgres
+spec:
+  type: ClusterIP
+  selector:
+    app: fl-postgres
+  ports:
+    - name: http
+      port: 5432
+      targetPort: 5432
+      protocol: TCP

--- a/kind/start_kind.sh
+++ b/kind/start_kind.sh
@@ -15,5 +15,6 @@ kubectl apply -f namespace.yml
 kubectl apply -f svc-account.yml
 kubectl apply -f prometheus-cm.yml
 kubectl apply -f prometheus.yml
+kubectl apply -f postgres.yml
 kubectl apply -f core.yml
 kubectl apply -f worker.yml


### PR DESCRIPTION
This PR adds three entities in the kind/k8s deployment:
- `fl-postgres` pod, holding the PostgreSQL instance
- `postgres` service, exposing the instance to the other services in the cluster (i.e. worker and core)
- `init-postgres` job, running the initial setup for the instance

It closes #11.

NOTE: the username and password in the pods are currently hardcoded in the yml file (similarly to the approach listed in #5). This should be changed in the future.