### PR TITLE
Improve handling of `SECRET_KEY_BASE` environment variable

### DIFF
--- a/docker-compose/.env.example
+++ b/docker-compose/.env.example
@@ -5,3 +5,5 @@ ELK_VERSION=7.17.8 # from 8.0 onwards SSL is on by default
 KIBANA_PORT=5601
 ELASTIC_PASSWORD=elasticpassword
 KIBANA_PASSWORD=kibanapassword
+
+SECRET_KEY_BASE=agoodexampleofasecretkey # SECRET_KEY_BASE must be at least 20 characters long

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -31,16 +31,13 @@ services:
       - PGPASSWORD=postgres
       - PGDATABASE=funless
       - PGPORT=5432
+      - SECRET_KEY_BASE=${SECRET_KEY_BASE}
     depends_on:
       init-postgres:
         condition: service_completed_successfully
-    # volumes:
-    #   - ./logs:/tmp/funless/
 
   worker:
     image: ghcr.io/funlessdev/worker:latest
-    # volumes:
-    #   - ./logs:/tmp/funless/
 
   prometheus:
     image: prom/prometheus:latest
@@ -88,7 +85,6 @@ services:
       - ./filebeat/filebeat.compose.yml:/usr/share/filebeat/filebeat.yml:ro
       - ${DOCKER_LIB:-/var/lib/docker}:/var/lib/docker:ro
       - ${DOCKER_SOCK:-/var/run/docker.sock}:/var/run/docker.sock
-      # - ${FL_LOGS:-./funless/}:/var/log/filebeat
 
   kibana:
     depends_on:

--- a/kind/core-secret-key-base.yml
+++ b/kind/core-secret-key-base.yml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: fl-core-secret-key-base
+  namespace: fl
+type: Opaque
+data:
+  # the value is the base64 encoding of "agoodexampleofasecretkey"
+  # this value __MUST__ be overwritten in production
+  secret_key_base: YWdvb2RleGFtcGxlb2Zhc2VjcmV0a2V5Cg==

--- a/kind/core.yml
+++ b/kind/core.yml
@@ -35,7 +35,10 @@ spec:
         - containerPort: 4369
         env:
         - name: SECRET_KEY_BASE
-          value: "core_secret_key"
+          valueFrom:
+            secretKeyRef:
+              name: fl-core-secret-key-base
+              key: secret_key_base
         - name: NODE_IP
           valueFrom:
             fieldRef:

--- a/kind/start_kind.sh
+++ b/kind/start_kind.sh
@@ -16,5 +16,6 @@ kubectl apply -f svc-account.yml
 kubectl apply -f prometheus-cm.yml
 kubectl apply -f prometheus.yml
 kubectl apply -f postgres.yml
+kubectl apply -f core-secret-key-base.yml
 kubectl apply -f core.yml
 kubectl apply -f worker.yml


### PR DESCRIPTION
This PR improves the way the `SECRET_KEY_BASE` env var is handled both in `docker-compose` and `kind` deployments.

This closes #5.

Specifically:
- in `docker-compose` the variable is now taken from the environment (similarly to the ElasticSearch password) and passed to the `core` service
- in `kind` the variable is now stored in a Secret, which is deployed separately