### PR TITLE
fix(kind): pass env correctly in core and postgres deployments

### DIFF
--- a/kind/core.yml
+++ b/kind/core.yml
@@ -39,12 +39,12 @@ spec:
             secretKeyRef:
               name: fl-core-secret-key-base
               key: secret_key_base
-        - name: POSTGRES_USER
+        - name: PGUSER
           valueFrom:
             secretKeyRef:
               name: fl-core-secret-postgres-user
               key: secret_key_user
-        - name: POSTGRES_PASSWORD
+        - name: PGPASSWORD
           valueFrom:
             secretKeyRef:
               name: fl-core-secret-postgres-password

--- a/kind/postgres.yml
+++ b/kind/postgres.yml
@@ -34,9 +34,15 @@ spec:
         - containerPort: 5432
         env:
         - name: POSTGRES_PASSWORD
-          value: ${POSTGRES_PASSWORD}
+          valueFrom:
+            secretKeyRef:
+              name: fl-core-secret-postgres-password
+              key: secret_key_password
         - name: POSTGRES_USER
-          value: ${POSTGRES_USER}
+          valueFrom:
+            secretKeyRef:
+              name: fl-core-secret-postgres-user
+              key: secret_key_user
         - name: POSTGRES_HOST_AUTH_METHOD
           value: trust
 
@@ -72,12 +78,18 @@ spec:
       - name: init-postgres
         image: "postgres:latest"
         imagePullPolicy: IfNotPresent
-        command:  ["/bin/bash", "-c", "while ! pg_isready -h postgres -U postgres; do sleep 1; done; psql -h postgres -U postgres -c 'CREATE DATABASE funless;'"]
+        command:  ["/bin/bash", "-c", "while ! pg_isready -h postgres -U ${POSTGRES_USER}; do sleep 1; done; psql -h postgres -U ${POSTGRES_USER} -c 'CREATE DATABASE funless;'"]
         env:
         - name: POSTGRES_PASSWORD
-          value: ${POSTGRES_PASSWORD}
+          valueFrom:
+            secretKeyRef:
+              name: fl-core-secret-postgres-password
+              key: secret_key_password
         - name: POSTGRES_USER
-          value: ${POSTGRES_USER}
+          valueFrom:
+            secretKeyRef:
+              name: fl-core-secret-postgres-user
+              key: secret_key_user
         - name: POSTGRES_HOST_AUTH_METHOD
           value: trust
 


### PR DESCRIPTION
- Use k8s secrets to pass `POSTGRES_USER` and `POSTGRES_PASSWORD` to the `postgres` deployment
- Change env vars for the `core` deployment to `PGUSER` and `PGPASSWORD`